### PR TITLE
bug fixed with node V14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "new-express-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "NPM package to create new pre-configured express app for REST API's from the command line",
   "main": "src/index.js",
   "bin": "src/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,9 +14,6 @@ exports.createDir = (filePath) => {
 exports.copyFile = async (projectName, src, dest) => {
   fs.copyFileSync(
     path.join(__dirname, '..', ...src),
-    path.join(process.cwd(), projectName, ...dest),
-    (err) => {
-      if (err) console.log(err);
-    }
+    path.join(process.cwd(), projectName, ...dest)
   );
 };


### PR DESCRIPTION
the copyFileSync method from the File system module doesn't receive a callback function in node V14 which caused the package to crash. removing the callback function was the fix.